### PR TITLE
Dont change the color of the most recently added spot's marker

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,8 +135,6 @@
             // useful bits from the original data
             var optionsJSON = ["name", "address", "city", "rowNumber"]
             var geoJSON = Sheetsee.createGeoJSON(gData, optionsJSON)
-            // change the color of the most recently added spot's marker
-            geoJSON[geoJSON.length - 1].properties["marker-color"] = "#FF4646"
 
             // create map, tilelayer (map background), markers and popups
             var map = Sheetsee.loadMap("map")


### PR DESCRIPTION
Fixes #26.

Turns out it was by design :cry: https://github.com/jlord/hack-spots/blob/8c65460501b5528c6aeb02abfd8ab824c991e235/index.html#L139

I think we should remove it because
1. it's confusing when you have assigned a hex color
2. without other markers being on the same map view it's unclear that the red means it different/new
