### PR TITLE
filter fixes

### DIFF
--- a/js/sheetsee.js
+++ b/js/sheetsee.js
@@ -16112,6 +16112,7 @@ module.exports.initiateTableFilter = function(opts) {
     $(this.id + ".noMatches").css("visibility", "hidden")
     $(this.id + opts.filterDiv).val("")
     makeTable(opts)
+    window.location.hash = ""
   })
   $(opts.filterDiv).keyup(function(e) {
     var text = $(e.target).val()

--- a/js/sheetsee.js
+++ b/js/sheetsee.js
@@ -16144,7 +16144,7 @@ function sortThings(opts, sorter, sorted, tableDiv) {
     return 0
   })
   if (sorted === "descending") opts.data.reverse()
-  makeTable(opts)
+  searchTable(opts, document.getElementById("tableFilter").value)
   var header
   $(tableDiv + " .tHeader").each(function(i, el){
     var contents = resolveDataTitle($(el).text())


### PR DESCRIPTION
previously, sorting the table by name, city, etc. would clear any filter in the input text field without removing it. now the filter still applies after sorting
